### PR TITLE
Fix generated site api endpoint

### DIFF
--- a/src/Traits/Console/EngezTrait.php
+++ b/src/Traits/Console/EngezTrait.php
@@ -239,7 +239,7 @@ trait EngezTrait
 
             // replace route prefix
             $routePrefix = strtolower($this->module);
-            $content = str_ireplace("route-prefix", "{$this->module}", $content);
+            $content = str_ireplace("route-prefix", "{$routePrefix}", $content);
 
             // create the route file
             $filePath = $routesDirectory . '/site.php';


### PR DESCRIPTION
# Description:  after create module generate file module/route/site.php , route name generated with "Upper Case" first latter 

# Expected
    Route::get('/site', 'SiteController@index');

# Actual
    Route::get('/Site', 'SiteController@index');