### PR TITLE
Fix generated admin & site api endpoint

### DIFF
--- a/src/Traits/Console/EngezTrait.php
+++ b/src/Traits/Console/EngezTrait.php
@@ -238,8 +238,8 @@ trait EngezTrait
             $content = str_ireplace("ModuleName", "{$targetModule}", $content);
 
             // replace route prefix
-            $routePrefix = strtolower($this->module);
-            $content = str_ireplace("route-prefix", "{$this->module}", $content);
+            $routePrefix = Str::kebab($this->module);
+            $content = str_ireplace("route-prefix", "{$routePrefix}", $content);
 
             // create the route file
             $filePath = $routesDirectory . '/site.php';
@@ -266,7 +266,7 @@ trait EngezTrait
             $content = str_ireplace("middlewareList", $middleware, $content);
 
             // replace route prefix
-            $routePrefix = strtolower($this->info['moduleName']);
+            $routePrefix = Str::kebab($this->info['moduleName']);
             $content = str_ireplace("route-prefix", "{$routePrefix}", $content);
 
             // create the route file


### PR DESCRIPTION
# Description: after create module generate file module/route/site.php , route name generated with "Upper Case" first latter
# Expected
```
Route::get('/site', 'SiteController@index');
 ```
 
# Actual
```
Route::get('/Site', 'SiteController@index');
 ```